### PR TITLE
Fix default secrets dir

### DIFF
--- a/get_docker_secret.py
+++ b/get_docker_secret.py
@@ -4,7 +4,7 @@ root = os.path.abspath(os.sep)
 
 
 def get_docker_secret(name, default=None, cast_to=str, autocast_name=True, getenv=True, safe=True,
-                      secrets_dir=os.path.join(root, 'var', 'run', 'secrets')):
+                      secrets_dir=os.path.join(root, 'run', 'secrets')):
     """This function fetches a docker secret
 
     :param name: the name of the docker secret


### PR DESCRIPTION
Hi, thanks for the package.

I tested it with a few of my containers based on debian and alpine, both ran into the same issue. I had to explicitly set the `secrets_dir=/run/secrets` as the default is not set to the default docker uses.

See [docker secrets documentation](https://docs.docker.com/engine/swarm/secrets/#how-docker-manages-secrets)